### PR TITLE
Reduced Docker image and make it more usable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.github/
+.pynb_checkpoints/
+dev/
+notebooks/
+input/
+models/
+!models/best_model.z
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.9-slim
 
-EXPOSE 8501
+COPY .docker/requirements.txt /
+RUN pip install -r /requirements.txt
+
+COPY . /app
 WORKDIR /app
 
-COPY . .
-RUN pip install -r .docker/requirements.txt
-CMD streamlit run src/app.py
+EXPOSE 8501
+ENTRYPOINT ["python"]

--- a/README.md
+++ b/README.md
@@ -22,8 +22,14 @@ docker build --tag app:1.0 .
 ### Enjoy the web application
 
 ```bash
-docker run --publish 8501:8501 -it app:1.0
+docker run --publish 8501:8501 -it app:1.0 -m streamlit run src/app.py
 ```
+
+Then access [http://localhost:8501](http://localhost:8501).
+
+### Enjoy the REST application
+
+> @TODO
 
 > Everytime you update the project, you must build a new image with a new tag.
 


### PR DESCRIPTION
As I like the developer experience of my previous build, I noticed the image was using too many files for a production setup.

I want this build to be used as a "production", not for developing purposes.

So I've opened the python as entrypoint and now people can use it as image to deploy the web app or the rest api.